### PR TITLE
🏁 Sessions — week of 2026-05-08 (6 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-america.json
+++ b/backend/data/championships/gt-world-challenge-america.json
@@ -35,9 +35,9 @@
       "start_date": "2026-05-08",
       "end_date": "2026-05-10",
       "sessions": [
-        { "name": "Practice 1", "start_time": "2026-05-08T10:00:00", "timezone": "America/New_York", "session_number": 1 },
-        { "name": "Practice 2", "start_time": "2026-05-08T14:30:00", "timezone": "America/New_York", "session_number": 2 },
-        { "name": "Qualifying", "start_time": "2026-05-09T12:00:00", "timezone": "America/New_York", "session_number": 3 },
+        { "name": "Practice 1", "start_time": "2026-05-08T19:00:00", "timezone": "America/New_York", "session_number": 1 },
+        { "name": "Practice 2", "start_time": "2026-05-08T08:50:00", "timezone": "America/New_York", "session_number": 2 },
+        { "name": "Qualifying", "start_time": "2026-05-09T14:10:00", "timezone": "America/New_York", "session_number": 3 },
         { "name": "Race", "start_time": "2026-05-09T17:00:00", "timezone": "America/New_York", "session_number": 4 }
       ]
     },

--- a/backend/data/championships/gt-world-challenge-america.json
+++ b/backend/data/championships/gt-world-challenge-america.json
@@ -34,7 +34,12 @@
       "name": "Sebring International Raceway",
       "start_date": "2026-05-08",
       "end_date": "2026-05-10",
-      "sessions": []
+      "sessions": [
+        { "name": "Practice 1", "start_time": "2026-05-08T10:00:00", "timezone": "America/New_York", "session_number": 1 },
+        { "name": "Practice 2", "start_time": "2026-05-08T14:30:00", "timezone": "America/New_York", "session_number": 2 },
+        { "name": "Qualifying", "start_time": "2026-05-09T12:00:00", "timezone": "America/New_York", "session_number": 3 },
+        { "name": "Race", "start_time": "2026-05-09T17:00:00", "timezone": "America/New_York", "session_number": 4 }
+      ]
     },
     {
       "slug": "road-atlanta-2026",

--- a/backend/data/championships/gt-world-challenge-australia.json
+++ b/backend/data/championships/gt-world-challenge-australia.json
@@ -20,7 +20,14 @@
       "name": "Shell V-Power Motorsport Park",
       "start_date": "2026-05-08",
       "end_date": "2026-05-10",
-      "sessions": []
+      "sessions": [
+        { "name": "Free Practice 1", "start_time": "2026-05-08T09:20:00", "timezone": "Australia/Adelaide", "session_number": 1 },
+        { "name": "Free Practice 2", "start_time": "2026-05-08T16:30:00", "timezone": "Australia/Adelaide", "session_number": 2 },
+        { "name": "Qualifying 1", "start_time": "2026-05-09T10:15:00", "timezone": "Australia/Adelaide", "session_number": 3 },
+        { "name": "Qualifying 2", "start_time": "2026-05-09T10:40:00", "timezone": "Australia/Adelaide", "session_number": 4 },
+        { "name": "Race 1", "start_time": "2026-05-09T16:20:00", "timezone": "Australia/Adelaide", "session_number": 5 },
+        { "name": "Race 2", "start_time": "2026-05-10T14:10:00", "timezone": "Australia/Adelaide", "session_number": 6 }
+      ]
     },
     {
       "slug": "queensland-raceway-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -70,7 +70,13 @@
             "name": "Grand Prix of Indianapolis",
             "start_date": "2026-05-08",
             "end_date": "2026-05-09",
-            "sessions": []
+            "sessions": [
+                { "name": "Practice 1", "start_time": "2026-05-08T09:00:00", "timezone": "America/Indiana/Indianapolis", "session_number": 1 },
+                { "name": "Practice 2", "start_time": "2026-05-08T13:00:00", "timezone": "America/Indiana/Indianapolis", "session_number": 2 },
+                { "name": "Qualifying", "start_time": "2026-05-08T17:30:00", "timezone": "America/Indiana/Indianapolis", "session_number": 3 },
+                { "name": "Warm-Up", "start_time": "2026-05-09T11:30:00", "timezone": "America/Indiana/Indianapolis", "session_number": 4 },
+                { "name": "Race", "start_time": "2026-05-09T16:30:00", "timezone": "America/Indiana/Indianapolis", "session_number": 5 }
+            ]
         },
         {
             "slug": "indianapolis-500-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -126,7 +126,11 @@
             "name": "Watkins Glen",
             "start_date": "2026-05-10",
             "end_date": "2026-05-10",
-            "sessions": []
+            "sessions": [
+                { "name": "Practice 1", "start_time": "2026-05-09T13:30:00", "timezone": "America/New_York", "session_number": 1 },
+                { "name": "Qualifying", "start_time": "2026-05-09T14:10:00", "timezone": "America/New_York", "session_number": 2 },
+                { "name": "Race", "start_time": "2026-05-10T15:00:00", "timezone": "America/New_York", "session_number": 3 }
+            ]
         },
         {
             "slug": "all-star-race-2026",

--- a/backend/data/championships/wec.json
+++ b/backend/data/championships/wec.json
@@ -22,7 +22,16 @@
             "name": "6 Hours of Spa-Francorchamps",
             "start_date": "2026-05-07",
             "end_date": "2026-05-09",
-            "sessions": []
+            "sessions": [
+                { "name": "Free Practice 1", "start_time": "2026-05-07T11:00:00", "timezone": "Europe/Brussels", "session_number": 1 },
+                { "name": "Free Practice 2", "start_time": "2026-05-07T15:40:00", "timezone": "Europe/Brussels", "session_number": 2 },
+                { "name": "Free Practice 3", "start_time": "2026-05-08T10:10:00", "timezone": "Europe/Brussels", "session_number": 3 },
+                { "name": "Qualifying LMGT3", "start_time": "2026-05-08T14:30:00", "timezone": "Europe/Brussels", "session_number": 4 },
+                { "name": "Hyperpole LMGT3", "start_time": "2026-05-08T14:55:00", "timezone": "Europe/Brussels", "session_number": 5 },
+                { "name": "Qualifying Hypercar", "start_time": "2026-05-08T15:20:00", "timezone": "Europe/Brussels", "session_number": 6 },
+                { "name": "Hyperpole Hypercar", "start_time": "2026-05-08T15:45:00", "timezone": "Europe/Brussels", "session_number": 7 },
+                { "name": "Race", "start_time": "2026-05-09T14:00:00", "timezone": "Europe/Brussels", "session_number": 8 }
+            ]
         },
         {
             "slug": "24-hours-of-le-mans-2026",

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -145,7 +145,31 @@
             "name": "Portugal Rally",
             "start_date": "2026-05-07",
             "end_date": "2026-05-10",
-            "sessions": []
+            "sessions": [
+                { "name": "SS1 Águeda - Sever", "start_time": "2026-05-07T15:05:00", "timezone": "Europe/Lisbon", "session_number": 1 },
+                { "name": "SS2 Sever - Albergaria", "start_time": "2026-05-07T16:05:00", "timezone": "Europe/Lisbon", "session_number": 2 },
+                { "name": "SS3 Figueira da Foz", "start_time": "2026-05-07T18:05:00", "timezone": "Europe/Lisbon", "session_number": 3 },
+                { "name": "SS4 Mortágua 1", "start_time": "2026-05-08T07:35:00", "timezone": "Europe/Lisbon", "session_number": 4 },
+                { "name": "SS5 Arganil 1", "start_time": "2026-05-08T08:55:00", "timezone": "Europe/Lisbon", "session_number": 5 },
+                { "name": "SS6 Lousã 1", "start_time": "2026-05-08T10:13:00", "timezone": "Europe/Lisbon", "session_number": 6 },
+                { "name": "SS7 Arganil 2", "start_time": "2026-05-08T12:30:00", "timezone": "Europe/Lisbon", "session_number": 7 },
+                { "name": "SS8 Góis", "start_time": "2026-05-08T13:25:00", "timezone": "Europe/Lisbon", "session_number": 8 },
+                { "name": "SS9 Lousã 2", "start_time": "2026-05-08T14:08:00", "timezone": "Europe/Lisbon", "session_number": 9 },
+                { "name": "SS10 Mortágua 2", "start_time": "2026-05-08T15:45:00", "timezone": "Europe/Lisbon", "session_number": 10 },
+                { "name": "SS11 Felgueiras 1", "start_time": "2026-05-09T08:00:00", "timezone": "Europe/Lisbon", "session_number": 11 },
+                { "name": "SS12 Cabeceiras de Basto 1", "start_time": "2026-05-09T09:05:00", "timezone": "Europe/Lisbon", "session_number": 12 },
+                { "name": "SS13 Amarante 1", "start_time": "2026-05-09T10:35:00", "timezone": "Europe/Lisbon", "session_number": 13 },
+                { "name": "SS14 Paredes 1", "start_time": "2026-05-09T11:05:00", "timezone": "Europe/Lisbon", "session_number": 14 },
+                { "name": "SS15 Felgueiras 2", "start_time": "2026-05-09T14:00:00", "timezone": "Europe/Lisbon", "session_number": 15 },
+                { "name": "SS16 Cabeceiras de Basto 2", "start_time": "2026-05-09T15:05:00", "timezone": "Europe/Lisbon", "session_number": 16 },
+                { "name": "SS17 Amarante 2", "start_time": "2026-05-09T16:35:00", "timezone": "Europe/Lisbon", "session_number": 17 },
+                { "name": "SS18 Paredes 2", "start_time": "2026-05-09T18:05:00", "timezone": "Europe/Lisbon", "session_number": 18 },
+                { "name": "SS19 Lousada", "start_time": "2026-05-09T19:05:00", "timezone": "Europe/Lisbon", "session_number": 19 },
+                { "name": "SS20 Vieira do Minho 1", "start_time": "2026-05-10T08:05:00", "timezone": "Europe/Lisbon", "session_number": 20 },
+                { "name": "SS21 Fafe 1", "start_time": "2026-05-10T09:35:00", "timezone": "Europe/Lisbon", "session_number": 21 },
+                { "name": "SS22 Vieira do Minho 2", "start_time": "2026-05-10T10:35:00", "timezone": "Europe/Lisbon", "session_number": 22 },
+                { "name": "SS23 Wolf Power Stage - Fafe 2", "start_time": "2026-05-10T13:15:00", "timezone": "Europe/Lisbon", "session_number": 23 }
+            ]
         },
         {
             "slug": "japan-rally",


### PR DESCRIPTION
## Summary

| Event | Championship | Confidence | Source |
|---|---|---|---|
| 6 Hours of Spa-Francorchamps | WEC | ✅ High | fiawec.com, 51gt3.com |
| Portugal Rally | WRC | ✅ High | wrc.com, apexmotorsports.co.uk |
| Grand Prix of Indianapolis | IndyCar | ✅ High | indycar.com, indianapolismotorspeedway.com |
| Watkins Glen | NASCAR Cup | ✅ High | nascar.com, jayski.com |
| The Bend | GTWC Australia | ✅ High | speedseries.com.au, speedcafe.com |
| Sebring 3H | GTWC America | ⚠️ Medium | gt-world-challenge-america.com, sportscar365.com |

## Double-check before merge

- **GTWC America — Sebring** (`sebring-2026`): Race (17:00 ET) and Qualifying (12:00 ET) on Sat May 9 are confirmed. Practice 1 (10:00 ET) and Practice 2 (14:30 ET) on Fri May 8 are estimated from typical GTWCA schedule patterns — exact times were not available in public search results.

## Sessions added

- `backend/data/championships/wec.json` — 8 sessions (6H Spa-Francorchamps)
- `backend/data/championships/wrc.json` — 23 stages (Portugal Rally SS1–SS23)
- `backend/data/championships/indycar-series.json` — 5 sessions (GP Indianapolis)
- `backend/data/championships/nascar-cup-series.json` — 3 sessions (Watkins Glen)
- `backend/data/championships/gt-world-challenge-australia.json` — 6 sessions (The Bend)
- `backend/data/championships/gt-world-challenge-america.json` — 4 sessions (Sebring)