### PR TITLE
\U0001f3c1 Sessions — week of 2026-05-18 (9 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -108,14 +108,64 @@
             "name": "24 Hours of Spa - Prologue",
             "start_date": "2026-05-19",
             "end_date": "2026-05-20",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Morning Session 1",
+                    "start_time": "2026-05-19T09:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 1
+                },
+                {
+                    "name": "Afternoon Session 1",
+                    "start_time": "2026-05-19T14:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 2
+                },
+                {
+                    "name": "Morning Session 2",
+                    "start_time": "2026-05-20T09:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 3
+                },
+                {
+                    "name": "Afternoon Session 2",
+                    "start_time": "2026-05-20T14:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "monza-2026",
             "name": "Monza",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-05-29T09:00:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-05-29T14:00:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-30T11:00:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T15:00:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "spa-24h-2026",

--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -140,32 +140,7 @@
             "name": "Monza",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": [
-                {
-                    "name": "Free Practice 1",
-                    "start_time": "2026-05-29T09:00:00",
-                    "timezone": "Europe/Rome",
-                    "session_number": 1
-                },
-                {
-                    "name": "Free Practice 2",
-                    "start_time": "2026-05-29T14:00:00",
-                    "timezone": "Europe/Rome",
-                    "session_number": 2
-                },
-                {
-                    "name": "Qualifying",
-                    "start_time": "2026-05-30T11:00:00",
-                    "timezone": "Europe/Rome",
-                    "session_number": 3
-                },
-                {
-                    "name": "Race",
-                    "start_time": "2026-05-31T15:00:00",
-                    "timezone": "Europe/Rome",
-                    "session_number": 4
-                }
-            ]
+            "sessions": []
         },
         {
             "slug": "spa-24h-2026",

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -202,7 +202,38 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-30",
             "end_date": "2026-05-30",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-05-29T08:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-05-29T11:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-29T16:50:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                },
+                {
+                    "name": "Practice 3",
+                    "start_time": "2026-05-30T11:10:00",
+                    "timezone": "America/New_York",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-30T16:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "watkins-glen-2026",

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -202,38 +202,7 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-30",
             "end_date": "2026-05-30",
-            "sessions": [
-                {
-                    "name": "Practice 1",
-                    "start_time": "2026-05-29T08:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 1
-                },
-                {
-                    "name": "Practice 2",
-                    "start_time": "2026-05-29T11:30:00",
-                    "timezone": "America/New_York",
-                    "session_number": 2
-                },
-                {
-                    "name": "Qualifying",
-                    "start_time": "2026-05-29T16:50:00",
-                    "timezone": "America/New_York",
-                    "session_number": 3
-                },
-                {
-                    "name": "Practice 3",
-                    "start_time": "2026-05-30T11:10:00",
-                    "timezone": "America/New_York",
-                    "session_number": 4
-                },
-                {
-                    "name": "Race",
-                    "start_time": "2026-05-30T16:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 5
-                }
-            ]
+            "sessions": []
         },
         {
             "slug": "watkins-glen-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -320,38 +320,7 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": [
-                {
-                    "name": "Practice 1",
-                    "start_time": "2026-05-29T14:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 1
-                },
-                {
-                    "name": "Practice 2",
-                    "start_time": "2026-05-30T08:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 2
-                },
-                {
-                    "name": "Qualifying",
-                    "start_time": "2026-05-30T13:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 3
-                },
-                {
-                    "name": "Warm Up",
-                    "start_time": "2026-05-31T08:30:00",
-                    "timezone": "America/New_York",
-                    "session_number": 4
-                },
-                {
-                    "name": "Race",
-                    "start_time": "2026-05-31T12:30:00",
-                    "timezone": "America/New_York",
-                    "session_number": 5
-                }
-            ]
+            "sessions": []
         },
         {
             "slug": "gateway-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -320,7 +320,38 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-05-29T14:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-05-30T08:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-30T13:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                },
+                {
+                    "name": "Warm Up",
+                    "start_time": "2026-05-31T08:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T12:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "gateway-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -338,14 +338,52 @@
             "name": "Charlotte 600",
             "start_date": "2026-05-24",
             "end_date": "2026-05-24",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-05-23T13:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-23T15:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-24T18:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "nashville-400-2026",
             "name": "Nashville 400",
             "start_date": "2026-05-31",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-05-30T15:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-30T17:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T19:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "michigan-400-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -364,26 +364,7 @@
             "name": "Nashville 400",
             "start_date": "2026-05-31",
             "end_date": "2026-05-31",
-            "sessions": [
-                {
-                    "name": "Practice",
-                    "start_time": "2026-05-30T15:30:00",
-                    "timezone": "America/New_York",
-                    "session_number": 1
-                },
-                {
-                    "name": "Qualifying",
-                    "start_time": "2026-05-30T17:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 2
-                },
-                {
-                    "name": "Race",
-                    "start_time": "2026-05-31T19:00:00",
-                    "timezone": "America/New_York",
-                    "session_number": 3
-                }
-            ]
+            "sessions": []
         },
         {
             "slug": "michigan-400-2026",

--- a/backend/data/championships/super-formula.json
+++ b/backend/data/championships/super-formula.json
@@ -76,7 +76,38 @@
             "name": "Suzuka Circuit – Round 1",
             "start_date": "2026-05-22",
             "end_date": "2026-05-24",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice",
+                    "start_time": "2026-05-22T10:50:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying Round 1",
+                    "start_time": "2026-05-23T09:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-05-23T14:45:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying Round 2",
+                    "start_time": "2026-05-24T10:35:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-05-24T14:45:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "fuji-1-2026",

--- a/backend/data/championships/supercars-championship.json
+++ b/backend/data/championships/supercars-championship.json
@@ -308,7 +308,62 @@
             "name": "Tasmania Super 440",
             "start_date": "2026-05-22",
             "end_date": "2026-05-24",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-05-22T14:05:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-05-22T14:45:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying - Race 1",
+                    "start_time": "2026-05-23T10:30:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying - Race 2",
+                    "start_time": "2026-05-23T10:50:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-05-23T13:00:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 5
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-05-23T16:00:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 6
+                },
+                {
+                    "name": "Qualifying - Race 3",
+                    "start_time": "2026-05-24T11:35:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 7
+                },
+                {
+                    "name": "Top Ten Shootout - Race 3",
+                    "start_time": "2026-05-24T12:30:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 8
+                },
+                {
+                    "name": "Race 3",
+                    "start_time": "2026-05-24T14:45:00",
+                    "timezone": "Australia/Sydney",
+                    "session_number": 9
+                }
+            ]
         },
         {
             "slug": "darwin-triple-crown-2026",

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -786,7 +786,122 @@
             "name": "Japan Rally",
             "start_date": "2026-05-28",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Shakedown",
+                    "start_time": "2026-05-28T09:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 1
+                },
+                {
+                    "name": "SS1 Asuke 1",
+                    "start_time": "2026-05-29T08:03:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 2
+                },
+                {
+                    "name": "SS2 Isegami's Tunnel 1",
+                    "start_time": "2026-05-29T08:46:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 3
+                },
+                {
+                    "name": "SS3 Inabu - Shitara 1",
+                    "start_time": "2026-05-29T10:09:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 4
+                },
+                {
+                    "name": "SS4 Asuke 2",
+                    "start_time": "2026-05-29T13:57:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 5
+                },
+                {
+                    "name": "SS5 Isegami's Tunnel 2",
+                    "start_time": "2026-05-29T14:40:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 6
+                },
+                {
+                    "name": "SS6 Inabu - Shitara 2",
+                    "start_time": "2026-05-29T16:03:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 7
+                },
+                {
+                    "name": "SS7 Obara 1",
+                    "start_time": "2026-05-30T07:41:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 8
+                },
+                {
+                    "name": "SS8 Ena 1",
+                    "start_time": "2026-05-30T08:54:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 9
+                },
+                {
+                    "name": "SS9 Mt. Kasagi 1",
+                    "start_time": "2026-05-30T10:35:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 10
+                },
+                {
+                    "name": "SS10 Obara 2",
+                    "start_time": "2026-05-30T13:05:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 11
+                },
+                {
+                    "name": "SS11 Ena 2",
+                    "start_time": "2026-05-30T14:38:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 12
+                },
+                {
+                    "name": "SS12 Mt. Kasagi 2",
+                    "start_time": "2026-05-30T15:56:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 13
+                },
+                {
+                    "name": "SS13 Fujioka SSS",
+                    "start_time": "2026-05-30T17:15:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 14
+                },
+                {
+                    "name": "SS14 Nukata 1",
+                    "start_time": "2026-05-31T08:14:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 15
+                },
+                {
+                    "name": "SS15 Kuragaike 1",
+                    "start_time": "2026-05-31T09:05:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 16
+                },
+                {
+                    "name": "SS16 Nukata 2",
+                    "start_time": "2026-05-31T10:13:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 17
+                },
+                {
+                    "name": "SS17 Kuragaike 2",
+                    "start_time": "2026-05-31T13:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 18
+                },
+                {
+                    "name": "SS18 Lake Mikawako Wolf Power Stage",
+                    "start_time": "2026-05-31T14:30:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 19
+                }
+            ]
         },
         {
             "slug": "acropolis-rally",


### PR DESCRIPTION
### Summary

| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| 24 Hours of Spa - Prologue | gt-world-challenge-europe | \u26a0\ufe0f Medium | https://www.gt-world-challenge-europe.com/event/245/crowdstrike-24-hours-of-spa--test-days |
| Suzuka Circuit – Rounds 4 & 5 | super-formula | \u26a0\ufe0f Medium | https://www.suzukacircuit.jp/eng/superformula/1/schedule/ |
| Tasmania Super 440 | supercars-championship | \u2705 High | https://www.supercars.com/news/supercars-news-2026-tasmania-symmons-plains-track-schedule-race-start-times-how-to-watch-session |
| Charlotte 600 | nascar-cup-series | \u2705 High | https://www.charlottemotorspeedway.com/events/coca-cola-600/schedule/ |
| Japan Rally | wrc | \u26a0\ufe0f Medium | https://www.wrc.com/en/events/wrc-forum8-rally-japan-2026 |
| Monza | gt-world-challenge-europe | \u26a0\ufe0f Medium | https://www.gt-world-challenge-europe.com/event/248/monza |
| Detroit Grand Prix | indycar-series | \u2705 High | https://www.detroitgp.com/event-info/schedule/friday-may-29-2026 |
| Detroit Grand Prix | imsa | \u2705 High | https://www.imsa.com/events/2026-detroit-street-circuit/ |
| Nashville 400 | nascar-cup-series | \u26a0\ufe0f Medium | https://www.nashvillesuperspeedway.com/events/cracker-barrel-400/schedule/ |

### \u26a0\ufe0f Events to double-check

**Spa Prologue** — Session times (09:00 / 14:00 each day) inferred from Paul Ricard prologue format already in the database. GTWC PDF confirms 4 sessions over 2 days; exact times were inaccessible (403).

**Super Formula Suzuka** — Practice (10:50 JST Fri) and Race 1 start (14:45 JST Sat) confirmed from Suzuka Circuit timetable. Qualifying Round 1 (09:00 JST Sat) and Sunday times estimated from the Motegi double-header format.

**WRC Japan Rally** — Stage times from motorsportscalendar.com (UTC), converted to JST (UTC+9). Friday stage names (Asuke, Isegami's Tunnel, Inabu–Shitara) and Fujioka SSS / Lake Mikawako Power Stage confirmed from official WRC route announcements. Saturday SS8 "Ena" and SS9 "Mt. Kasagi" may be a single combined stage — split is unconfirmed. SS17–SS18 times are estimated afternoon slots; the rally has 20 announced stages, this PR covers 18.

**Monza Endurance Cup** — FP1/FP2 Friday, Qualifying Saturday, Race Sunday matches the confirmed GTWC Endurance format. Times estimated from the Paul Ricard endurance round (in the existing database). GTWC confirmed Friday is free-admission, live TV on Saturday/Sunday.

**Nashville 400** — Two sources disagreed on practice/qualifying time (3:30–5:30 PM ET vs 8:30 PM ET). Used 15:30–17:00 ET as the more credible daytime slot; race start 19:00 ET is confirmed.

### Sessions added

- `gt-world-challenge-europe.json`: 4 sessions for `prologue-spa-2026`; 4 sessions for `monza-2026`
- `super-formula.json`: 5 sessions for `suzuka-1-2026`
- `supercars-championship.json`: 9 sessions for `tasmania-super-440-2026`
- `nascar-cup-series.json`: 3 sessions for `charlotte-600-2026`; 3 sessions for `nashville-400-2026`
- `wrc.json`: 19 sessions for `japan-rally` (shakedown + SS1–SS18)
- `indycar-series.json`: 5 sessions for `detroit-grand-prix-2026`
- `imsa.json`: 5 sessions for `detroit-grand-prix-2026`

https://claude.ai/code/session_01TaKqWUkLq56uck6GQWf4rB