### PR TITLE
🏁 Sessions — week of 2026-05-25 (4 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -140,7 +140,26 @@
             "name": "Monza",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-05-30T10:10:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-31T09:50:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T15:30:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "spa-24h-2026",

--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -142,22 +142,40 @@
             "end_date": "2026-05-31",
             "sessions": [
                 {
-                    "name": "Free Practice 1",
-                    "start_time": "2026-05-30T10:10:00",
+                    "name": "Bronze Test",
+                    "start_time": "2026-05-28T15:45:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 0
+                },
+                {
+                    "name": "Official Paid Test Session 1",
+                    "start_time": "2026-05-29T16:50:00",
                     "timezone": "Europe/Rome",
                     "session_number": 1
+                },
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-05-30T09:00:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 2
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-05-30T14:25:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 3
                 },
                 {
                     "name": "Qualifying",
                     "start_time": "2026-05-31T09:50:00",
                     "timezone": "Europe/Rome",
-                    "session_number": 2
+                    "session_number": 4
                 },
                 {
-                    "name": "Race",
+                    "name": "Main Race",
                     "start_time": "2026-05-31T15:30:00",
                     "timezone": "Europe/Rome",
-                    "session_number": 3
+                    "session_number": 5
                 }
             ]
         },

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -202,7 +202,38 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-30",
             "end_date": "2026-05-30",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "session_number": 1,
+                    "start_time": "2026-05-29T08:00:00",
+                    "timezone": "America/Detroit"
+                },
+                {
+                    "name": "Practice 2",
+                    "session_number": 2,
+                    "start_time": "2026-05-29T11:30:00",
+                    "timezone": "America/Detroit"
+                },
+                {
+                    "name": "Qualifying",
+                    "session_number": 3,
+                    "start_time": "2026-05-29T16:50:00",
+                    "timezone": "America/Detroit"
+                },
+                {
+                    "name": "Practice 3",
+                    "session_number": 4,
+                    "start_time": "2026-05-30T11:10:00",
+                    "timezone": "America/Detroit"
+                },
+                {
+                    "name": "Race",
+                    "session_number": 5,
+                    "start_time": "2026-05-30T16:10:00",
+                    "timezone": "America/Detroit"
+                }
+            ]
         },
         {
             "slug": "watkins-glen-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -320,7 +320,38 @@
             "name": "Detroit Grand Prix",
             "start_date": "2026-05-29",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-05-29T15:00:00",
+                    "timezone": "America/Detroit",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-05-30T09:00:00",
+                    "timezone": "America/Detroit",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-30T13:00:00",
+                    "timezone": "America/Detroit",
+                    "session_number": 3
+                },
+                {
+                    "name": "Warm-Up",
+                    "start_time": "2026-05-31T09:30:00",
+                    "timezone": "America/Detroit",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T12:30:00",
+                    "timezone": "America/Detroit",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "gateway-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -367,13 +367,13 @@
             "sessions": [
                 {
                     "name": "Practice 1",
-                    "start_time": "2026-05-30T14:30:00",
+                    "start_time": "2026-05-30T15:30:00",
                     "timezone": "America/Chicago",
                     "session_number": 1
                 },
                 {
                     "name": "Qualifying",
-                    "start_time": "2026-05-30T15:30:00",
+                    "start_time": "2026-05-30T16:30:00",
                     "timezone": "America/Chicago",
                     "session_number": 2
                 },

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -364,7 +364,26 @@
             "name": "Nashville 400",
             "start_date": "2026-05-31",
             "end_date": "2026-05-31",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-05-30T14:30:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-05-30T15:30:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-05-31T18:00:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "michigan-400-2026",


### PR DESCRIPTION
### Summary

| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Monza | gt-world-challenge-europe | ⚠️ Medium | [gt-world-challenge-europe.com](https://www.gt-world-challenge-europe.com/event/248/monza) |
| Detroit Grand Prix | indycar-series | ⚠️ Medium | [indycar.com](https://www.indycar.com/Schedule/2026/Detroit) / [motorsportscalendar.com](https://motorsportscalendar.com/event/indycar-2026-chevrolet-detroit-grand-prix) |
| Detroit Grand Prix | imsa | ✅ High | [imsa.com](https://www.imsa.com/events/2026-detroit-street-circuit/) / [detroitgp.com](https://www.detroitgp.com/event-info/schedule/friday-may-29-2026) |
| Nashville 400 | nascar-cup-series | ⚠️ Medium | [nashvillesuperspeedway.com](https://www.nashvillesuperspeedway.com/events/cracker-barrel-400/schedule/) / [nascar.com](https://www.nascar.com/nascar-cup-series/2026/schedule/) |

### ⚠️ Events to double-check

**GT World Challenge Europe — Monza** (Medium)
- Free Practice 1 time (10:10 CEST Saturday) is estimated from the 2025 Monza timetable; no 2026 article explicitly confirmed FP1 time. Qualifying (09:50) and Race (15:30) on Sunday are confirmed by multiple 2026 sources.
- FP2 could not be confirmed and was omitted. Typical Endurance Cup weekends have two Saturday practice sessions.

**IndyCar — Detroit Grand Prix** (Medium)
- Race time (12:30 PM ET Sunday) is confirmed by indycar.com, detroitgp.com and FOX Sports broadcast listing.
- Practice 1 (Fri 15:00), Practice 2 (Sat 09:00), Qualifying (Sat 13:00) and Warm-Up (Sun 09:30) come from third-party aggregators (motorsportscalendar.com, motorsportradar.com). Times are internally consistent and the race time cross-validates, but not independently confirmed by the official IndyCar site.

**NASCAR Cup Series — Nashville 400** (Medium)
- The official name is "Cracker Barrel 400" (stored in repo as "Nashville 400").
- Race (18:00 CT Sunday) confirmed by Nashville Superspeedway's own event page.
- Practice 1 (14:30 CT Saturday) confirmed from NASCAR.com's weekend schedule. Qualifying time (15:30 CT) is an estimate — practice and qualifying share a single 14:30–16:30 CT window; the split point is unconfirmed.

### Sessions added

**`gt-world-challenge-europe.json` — Monza:**
- Free Practice 1 — Sat 30 May 10:10 CEST
- Qualifying — Sun 31 May 09:50 CEST
- Race — Sun 31 May 15:30 CEST

**`indycar-series.json` — Detroit Grand Prix:**
- Practice 1 — Fri 29 May 15:00 EDT
- Practice 2 — Sat 30 May 09:00 EDT
- Qualifying — Sat 30 May 13:00 EDT
- Warm-Up — Sun 31 May 09:30 EDT
- Race — Sun 31 May 12:30 EDT

**`imsa.json` — Detroit Grand Prix:**
- Practice 1 — Fri 29 May 08:00 EDT
- Practice 2 — Fri 29 May 11:30 EDT
- Qualifying — Fri 29 May 16:50 EDT
- Practice 3 — Sat 30 May 11:10 EDT
- Race — Sat 30 May 16:10 EDT

**`nascar-cup-series.json` — Nashville 400:**
- Practice 1 — Sat 30 May 14:30 CT
- Qualifying — Sat 30 May 15:30 CT (estimated)
- Race — Sun 31 May 18:00 CT