### PR TITLE
🏁 Sessions — week of 2026-06-22 (5 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -184,7 +184,68 @@
             "name": "24 Hours of Spa",
             "start_date": "2026-06-24",
             "end_date": "2026-06-28",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-06-25T10:10:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-06-25T16:10:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1",
+                    "start_time": "2026-06-25T19:45:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying 2",
+                    "start_time": "2026-06-25T20:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 3",
+                    "start_time": "2026-06-25T20:35:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 5
+                },
+                {
+                    "name": "Qualifying 4",
+                    "start_time": "2026-06-25T21:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 6
+                },
+                {
+                    "name": "Night Practice",
+                    "start_time": "2026-06-25T21:55:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 7
+                },
+                {
+                    "name": "Superpole",
+                    "start_time": "2026-06-26T15:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 8
+                },
+                {
+                    "name": "Warm Up",
+                    "start_time": "2026-06-26T19:20:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 9
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-06-27T16:30:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 10
+                }
+            ]
         },
         {
             "slug": "misano-2026",

--- a/backend/data/championships/igtc.json
+++ b/backend/data/championships/igtc.json
@@ -118,7 +118,68 @@
             "name": "24 Hours of Spa",
             "start_date": "2026-06-25",
             "end_date": "2026-06-28",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-06-25T10:10:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-06-25T16:10:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1",
+                    "start_time": "2026-06-25T19:45:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying 2",
+                    "start_time": "2026-06-25T20:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 3",
+                    "start_time": "2026-06-25T20:35:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 5
+                },
+                {
+                    "name": "Qualifying 4",
+                    "start_time": "2026-06-25T21:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 6
+                },
+                {
+                    "name": "Night Practice",
+                    "start_time": "2026-06-25T21:55:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 7
+                },
+                {
+                    "name": "Superpole",
+                    "start_time": "2026-06-26T15:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 8
+                },
+                {
+                    "name": "Warm Up",
+                    "start_time": "2026-06-26T19:20:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 9
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-06-27T16:30:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 10
+                }
+            ]
         },
         {
             "slug": "suzuka-1000km-2026",

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -240,7 +240,32 @@
             "name": "Watkins Glen",
             "start_date": "2026-06-28",
             "end_date": "2026-06-28",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-06-26T11:25:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-06-27T10:05:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-06-27T15:40:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-06-28T12:10:00",
+                    "timezone": "America/New_York",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "mosport-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -438,7 +438,26 @@
             "name": "Sonoma 350",
             "start_date": "2026-06-28",
             "end_date": "2026-06-28",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-06-27T11:00:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-06-27T12:10:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-06-28T12:30:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "chicagoland-400-2026",

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -908,7 +908,116 @@
             "name": "Acropolis Rally",
             "start_date": "2026-06-25",
             "end_date": "2026-06-28",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Shakedown",
+                    "start_time": "2026-06-25T09:01:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 1
+                },
+                {
+                    "name": "SS1 EKO SSS",
+                    "start_time": "2026-06-25T19:05:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 2
+                },
+                {
+                    "name": "SS2 Bauxites",
+                    "start_time": "2026-06-26T08:48:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 3
+                },
+                {
+                    "name": "SS3 Parnassos Mt",
+                    "start_time": "2026-06-26T09:51:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 4
+                },
+                {
+                    "name": "SS4 Stiri 1",
+                    "start_time": "2026-06-26T11:14:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 5
+                },
+                {
+                    "name": "SS5 Elikon Mt",
+                    "start_time": "2026-06-26T13:35:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 6
+                },
+                {
+                    "name": "SS6 Stiri 2",
+                    "start_time": "2026-06-26T14:46:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 7
+                },
+                {
+                    "name": "SS7 Thiva",
+                    "start_time": "2026-06-26T16:56:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 8
+                },
+                {
+                    "name": "SS8 Ghymno 1",
+                    "start_time": "2026-06-27T07:54:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 9
+                },
+                {
+                    "name": "SS9 Kolines",
+                    "start_time": "2026-06-27T09:19:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 10
+                },
+                {
+                    "name": "SS10 Menalo Mt 1",
+                    "start_time": "2026-06-27T11:05:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 11
+                },
+                {
+                    "name": "SS11 Kefalari",
+                    "start_time": "2026-06-27T12:58:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 12
+                },
+                {
+                    "name": "SS12 Ghymno 2",
+                    "start_time": "2026-06-27T16:39:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 13
+                },
+                {
+                    "name": "SS13 Menalo Mt 2",
+                    "start_time": "2026-06-27T19:05:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 14
+                },
+                {
+                    "name": "SS14 Aghii Theodori 1",
+                    "start_time": "2026-06-28T08:28:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 15
+                },
+                {
+                    "name": "SS15 Loutraki 1",
+                    "start_time": "2026-06-28T09:35:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 16
+                },
+                {
+                    "name": "SS16 Aghii Theodori 2",
+                    "start_time": "2026-06-28T12:10:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 17
+                },
+                {
+                    "name": "SS17 Loutraki 2 - Wolf Power Stage",
+                    "start_time": "2026-06-28T14:15:00",
+                    "timezone": "Europe/Athens",
+                    "session_number": 18
+                }
+            ]
         },
         {
             "slug": "estonia-rally",


### PR DESCRIPTION
## Summary

Filled in session timetables for the 5 upcoming events returned by `GET /events/upcoming` that had an empty/missing `sessions` array. (The Dutch GP / MotoGP and Austrian GP / F1 events were also in the response but already have sessions, so they were skipped.)

| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| 24 Hours of Spa | gt-world-challenge-europe | ✅ High | [gt-world-challenge-europe.com](https://www.gt-world-challenge-europe.com/event/249/crowdstrike-24-hours-of-spa) · [crowdstrike24hoursofspa.com](https://www.crowdstrike24hoursofspa.com/programme) |
| 24 Hours of Spa | igtc | ✅ High | [intercontinentalgtchallenge.com](https://www.intercontinentalgtchallenge.com/event/151/crowdstrike-24-hours-of-spa) |
| Acropolis Rally | wrc | ⚠️ Medium | [wrc.com itinerary](https://www.wrc.com/en/events/wrc-eko-acropolis-rally-greece-2026/itinerary-wrc-eko-acropolis-rally-greece-2026) · [ewrc-results.com](https://ewrc-results.com/event/96262-eko-acropolis-rally-greece-2026/itinerary) |
| Sonoma 350 | nascar-cup-series | ✅ High | [sonomaraceway.com](https://www.sonomaraceway.com/events/toyota-save-mart-350/schedule/) |
| Watkins Glen | imsa | ✅ High | [imsa.com official schedule](https://www.imsa.com/events/2026-watkins-glen-international/) |

### ⚠️ Events to double-check

- **Acropolis Rally (wrc) — Medium.** The 17-stage itinerary plus shakedown was taken from the official WRC/eWRC itinerary, but rally stage **start times are provisional** and routinely shift in the days before the event. Times are in `Europe/Athens` (EEST, UTC+3). Stage names are kept verbatim per the WRC naming convention (including the SS1 super special stage and the SS17 Power Stage). Worth re-checking the final road book closer to 25–28 June.

All other events are High confidence (sourced from official championship/circuit schedules; the two Spa entries are the same physical race cross-confirmed by two official sources).

### Sessions added

- **`gt-world-challenge-europe.json`** — `spa-24h-2026`: 10 sessions (Free Practice 1–2, Qualifying 1–4, Night Practice, Superpole, Warm Up, Race @ 16:30 CEST Sat 27 Jun), `Europe/Brussels`.
- **`igtc.json`** — `24-hours-of-spa-2026`: same 10-session timetable as above (same physical event), `Europe/Brussels`.
- **`wrc.json`** — `acropolis-rally`: 18 sessions (Shakedown + SS1–SS17 incl. Wolf Power Stage), `Europe/Athens`.
- **`nascar-cup-series.json`** — `sonoma-350-2026`: 3 sessions (Practice 11:00, Qualifying 12:10 Sat; Race 12:30 Sun), `America/Los_Angeles`.
- **`imsa.json`** — `watkins-glen-imsa-2026`: 4 sessions (Practice 1 Fri 11:25, Practice 2 Sat 10:05, Qualifying Sat 15:40, Race Sun 12:10), `America/New_York`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U2SV3xVXegSbZ9u7Xx4jB

---
_Generated by [Claude Code](https://claude.ai/code/session_012U2SV3xVXegSbZ9u7Xx4jB)_