### PR TITLE
🏁 Sessions — week of 2026-07-13 (5 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -252,7 +252,44 @@
             "name": "Misano",
             "start_date": "2026-07-17",
             "end_date": "2026-07-19",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-07-17T14:50:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-07-17T20:10:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1",
+                    "start_time": "2026-07-18T13:05:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-07-18T20:30:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 2",
+                    "start_time": "2026-07-19T10:05:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 5
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-07-19T14:30:00",
+                    "timezone": "Europe/Rome",
+                    "session_number": 6
+                }
+            ]
         },
         {
             "slug": "magny-cours-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -446,7 +446,38 @@
             "name": "Music City Grand Prix",
             "start_date": "2026-07-17",
             "end_date": "2026-07-19",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-07-18T09:00:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-07-18T14:00:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 2
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-07-18T17:00:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 3
+                },
+                {
+                    "name": "Practice 3",
+                    "start_time": "2026-07-18T18:00:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-07-19T16:30:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "grand-prix-of-portland-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -497,7 +497,26 @@
             "name": "North Wilkesboro 450",
             "start_date": "2026-07-19",
             "end_date": "2026-07-19",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-07-18T17:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-07-18T18:10:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-07-19T19:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "brickyard-400-2026",

--- a/backend/data/championships/super-formula.json
+++ b/backend/data/championships/super-formula.json
@@ -114,7 +114,50 @@
             "name": "Fuji Speedway – Round 1",
             "start_date": "2026-07-17",
             "end_date": "2026-07-19",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-07-17T11:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-07-17T14:50:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying Round 1",
+                    "start_time": "2026-07-18T08:15:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying Round 2",
+                    "start_time": "2026-07-18T10:35:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-07-18T16:15:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 5
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-07-19T10:05:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 6
+                },
+                {
+                    "name": "Race 3",
+                    "start_time": "2026-07-19T15:35:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 7
+                }
+            ]
         },
         {
             "slug": "sugo-2026",

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -1027,7 +1027,7 @@
             "sessions": [
                 {
                     "name": "Shakedown",
-                    "start_time": "2026-07-17T09:01:00",
+                    "start_time": "2026-07-17T08:01:00",
                     "timezone": "Europe/Tallinn",
                     "session_number": 1
                 },

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -1024,7 +1024,122 @@
             "name": "Estonia Rally",
             "start_date": "2026-07-16",
             "end_date": "2026-07-19",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Shakedown",
+                    "start_time": "2026-07-17T09:01:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 1
+                },
+                {
+                    "name": "SS1 Raanitsa 1",
+                    "start_time": "2026-07-17T13:03:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 2
+                },
+                {
+                    "name": "SS2 Karaski 1",
+                    "start_time": "2026-07-17T13:56:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 3
+                },
+                {
+                    "name": "SS3 Kanepi 1",
+                    "start_time": "2026-07-17T14:49:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 4
+                },
+                {
+                    "name": "SS4 Raanitsa 2",
+                    "start_time": "2026-07-17T16:46:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 5
+                },
+                {
+                    "name": "SS5 Karaski 2",
+                    "start_time": "2026-07-17T17:39:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 6
+                },
+                {
+                    "name": "SS6 Kanepi 2",
+                    "start_time": "2026-07-17T18:32:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 7
+                },
+                {
+                    "name": "SS7 Elva Linn",
+                    "start_time": "2026-07-17T19:35:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 8
+                },
+                {
+                    "name": "SS8 Peipsiääre 1",
+                    "start_time": "2026-07-18T09:56:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 9
+                },
+                {
+                    "name": "SS9 Mustvee 1",
+                    "start_time": "2026-07-18T10:49:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 10
+                },
+                {
+                    "name": "SS10 Peipsiääre 2",
+                    "start_time": "2026-07-18T12:10:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 11
+                },
+                {
+                    "name": "SS11 Mustvee 2",
+                    "start_time": "2026-07-18T13:03:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 12
+                },
+                {
+                    "name": "SS12 Kambja 1",
+                    "start_time": "2026-07-18T15:48:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 13
+                },
+                {
+                    "name": "SS13 Otepää 1",
+                    "start_time": "2026-07-18T17:05:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 14
+                },
+                {
+                    "name": "SS14 Kambja 2",
+                    "start_time": "2026-07-18T17:58:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 15
+                },
+                {
+                    "name": "SS15 Otepää 2",
+                    "start_time": "2026-07-18T19:05:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 16
+                },
+                {
+                    "name": "SS16 Tartu vald",
+                    "start_time": "2026-07-18T20:35:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 17
+                },
+                {
+                    "name": "SS17 Kääriku 1",
+                    "start_time": "2026-07-19T11:05:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 18
+                },
+                {
+                    "name": "SS18 Kääriku 2 - Power Stage",
+                    "start_time": "2026-07-19T13:15:00",
+                    "timezone": "Europe/Tallinn",
+                    "session_number": 19
+                }
+            ]
         },
         {
             "slug": "finland-rally",


### PR DESCRIPTION
Automated session-timetable update. Sourced from `GET /events/upcoming`, keeping only events with an empty/missing session set (verified against each event's detail endpoint, which does serialize sessions — `/events/upcoming` never does).

**Belgian Grand Prix** was in the upcoming list but was **excluded**: it already has 5 sessions in the database (`/events/belgian-gp-2026`), so it was not re-populated.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Estonia Rally | wrc | ⚠️ Medium | [wikipedia.org/wiki/2026_Rally_Estonia](https://en.wikipedia.org/wiki/2026_Rally_Estonia) |
| Misano | gt-world-challenge-europe | ✅ High | [gt-world-challenge-europe.com](https://www.gt-world-challenge-europe.com/event/250/misano) |
| Fuji Speedway – Round 1 | super-formula | ⚠️ Medium | [fujispeedway.jp/motorsports/2026-sf-rd67](https://fujispeedway.jp/motorsports/2026-sf-rd67) |
| Music City Grand Prix | indycar-series | ✅ High | [musiccitygp.com/schedule](https://www.musiccitygp.com/schedule/saturday-july-18) |
| North Wilkesboro 450 | nascar-cup-series | ✅ High | [northwilkesborospeedway.com](https://www.northwilkesborospeedway.com/events/window-world-450/schedule/) |

### ⚠️ Events to double-check

- **Estonia Rally (Medium):** Stage names and SS numbering are cross-confirmed by Wikipedia and rally-maps.com (Raanitsa, Karaski, Kanepi, Kääriku Power Stage, etc.), but the per-stage **start times are provisional** — taken from Wikipedia's itinerary table rather than the official wrc.com itinerary (which returned no parseable content). WRC first-car times routinely shift as the final itinerary is published closer to the event. Shakedown is listed Fri 17 Jul; the Thu 16 Jul ceremonial start is not a timed stage and is excluded. Repeated stages use the WRC pass-number convention (e.g. "SS1 Raanitsa 1" / "SS4 Raanitsa 2"). Full stage names kept verbatim per WRC rules.
- **Fuji Speedway – Round 1 (Medium):** Two concerns. (1) **Round-label mismatch** — in the official 2026 Super Formula calendar, championship Round 1 is Motegi (April); this July 17–19 Fuji weekend is officially Rounds 6 & 7. The repo's `fuji-1-2026` slug appears to mean "first Fuji round of the year" rather than the championship round number, so the *weekend* mapped here is correct even though the "Round 1" label is ambiguous. (2) This weekend is an **unusual triple-header** (a double-header plus a rescheduled race → 3 races, 2 qualifying sessions). Times come from superformula.net and fujispeedway.jp (which agree) but are published as provisional (暫定). Sessions were renamed to the repo's clean convention (Free Practice 1/2, Qualifying Round 1/2, Race 1/2/3) rather than official round numbers.

### Sessions added

- **`wrc.json` → estonia-rally:** 19 sessions (Shakedown + SS1–SS18, ending with "SS18 Kääriku 2 - Power Stage"), timezone Europe/Tallinn.
- **`gt-world-challenge-europe.json` → misano-2026:** 6 sessions (Free Practice 1/2, Qualifying 1, Race 1, Qualifying 2, Race 2) — Sprint Cup twilight-race format, timezone Europe/Rome. Support series (GT2/GT4/McLaren Trophy) excluded.
- **`super-formula.json` → fuji-1-2026:** 7 sessions (Free Practice 1/2, Qualifying Round 1/2, Race 1/2/3), timezone Asia/Tokyo.
- **`indycar-series.json` → music-city-grand-prix-2026:** 5 sessions (Practice 1, Qualifying, Practice 2, Practice 3, Race) at Nashville Superspeedway oval, timezone America/Chicago. No Sunday warm-up; the 17:00 CT session is the official oval "High Line Practice", listed here as Practice 2.
- **`nascar-cup-series.json` → north-wilkesboro-450-2026:** 3 sessions (Practice, Qualifying, Race), timezone America/New_York. Now a points race (formerly the All-Star Race); support series excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ftkvZopT8AjJ8DNTknWQc

---
_Generated by [Claude Code](https://claude.ai/code/session_019ftkvZopT8AjJ8DNTknWQc)_