### PR TITLE
🏁 Sessions — week of 2026-07-20 (5 events)

### DIFF
--- a/backend/data/championships/dtm.json
+++ b/backend/data/championships/dtm.json
@@ -188,7 +188,44 @@
             "name": "Motorsport Arena Oschersleben",
             "start_date": "2026-07-23",
             "end_date": "2026-07-25",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "session_number": 1,
+                    "start_time": "2026-07-24T11:00:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Free Practice 2",
+                    "session_number": 2,
+                    "start_time": "2026-07-24T15:35:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Qualifying 1",
+                    "session_number": 3,
+                    "start_time": "2026-07-25T09:45:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Race 1",
+                    "session_number": 4,
+                    "start_time": "2026-07-25T13:30:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Qualifying 2",
+                    "session_number": 5,
+                    "start_time": "2026-07-26T09:25:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Race 2",
+                    "session_number": 6,
+                    "start_time": "2026-07-26T13:30:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
         },
         {
             "slug": "nurburgring-dtm-2026",

--- a/backend/data/championships/formula-e.json
+++ b/backend/data/championships/formula-e.json
@@ -146,14 +146,22 @@
             "name": "Tokyo E-Prix 2",
             "start_date": "2026-07-24",
             "end_date": "2026-07-24",
-            "sessions": []
+            "sessions": [
+            { "name": "Free Practice 1", "start_time": "2026-07-24T13:30:00", "timezone": "Asia/Tokyo", "session_number": 1 },
+            { "name": "Qualifying", "start_time": "2026-07-24T15:40:00", "timezone": "Asia/Tokyo", "session_number": 2 },
+            { "name": "Race", "start_time": "2026-07-24T20:05:00", "timezone": "Asia/Tokyo", "session_number": 3 }
+            ]
         },
         {
             "slug": "tokyo-eprix-1-2026",
             "name": "Tokyo E-Prix 1",
             "start_date": "2026-07-25",
             "end_date": "2026-07-25",
-            "sessions": []
+            "sessions": [
+            { "name": "Free Practice 1", "start_time": "2026-07-25T13:30:00", "timezone": "Asia/Tokyo", "session_number": 1 },
+            { "name": "Qualifying", "start_time": "2026-07-25T15:40:00", "timezone": "Asia/Tokyo", "session_number": 2 },
+            { "name": "Race", "start_time": "2026-07-25T20:05:00", "timezone": "Asia/Tokyo", "session_number": 3 }
+            ]
         },
         {
             "slug": "london-eprix-1-2026",

--- a/backend/data/championships/gt-world-challenge-australia.json
+++ b/backend/data/championships/gt-world-challenge-australia.json
@@ -48,7 +48,14 @@
       "name": "Hidden Valley Raceway",
       "start_date": "2026-07-24",
       "end_date": "2026-07-26",
-      "sessions": []
+      "sessions": [
+        { "name": "Free Practice 1", "start_time": "2026-07-24T12:50:00", "timezone": "Australia/Darwin", "session_number": 1 },
+        { "name": "Free Practice 2", "start_time": "2026-07-24T16:00:00", "timezone": "Australia/Darwin", "session_number": 2 },
+        { "name": "Qualifying 1", "start_time": "2026-07-25T10:15:00", "timezone": "Australia/Darwin", "session_number": 3 },
+        { "name": "Qualifying 2", "start_time": "2026-07-25T10:35:00", "timezone": "Australia/Darwin", "session_number": 4 },
+        { "name": "Race 1", "start_time": "2026-07-25T14:00:00", "timezone": "Australia/Darwin", "session_number": 5 },
+        { "name": "Race 2", "start_time": "2026-07-26T10:00:00", "timezone": "Australia/Darwin", "session_number": 6 }
+      ]
     },
     {
       "slug": "sydney-motorsport-park-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -536,7 +536,26 @@
             "name": "Brickyard 400",
             "start_date": "2026-07-26",
             "end_date": "2026-07-26",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-07-24T13:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-07-25T13:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-07-26T14:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "iowa-350-2026",


### PR DESCRIPTION
Automated session-timetable research for upcoming events returned by `GET /events/upcoming` that had **no sessions**.

> **Note on scope:** `/events/upcoming` returned 6 events. One of them, the **Hungarian Grand Prix** (`f1`), already has a full sessions array in the repo, so it was left untouched. The remaining **5 events** had empty `sessions: []` and are covered below.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Motorsport Arena Oschersleben | dtm | ✅ High | https://www.motorsport-magazin.com/dtm/ergebnisse/2026/oschersleben-9968.html |
| Brickyard 400 | nascar-cup-series | ✅ High | https://www.jayski.com/nascar-cup-series/2026-nascar-cup-series-indianapolis-motor-speedway-race-page/ |
| Hidden Valley Raceway | gt-world-challenge-australia | 🔴 Low | ``https://speedcafe.com/motorsport-news-2026-shannons-speedseries-gt-festival-darwin-hidden-valley-track-schedule-broadcast-details``/ |
| Tokyo E-Prix 1 | formula-e | 🔴 Low | https://www.fiaformulae.com/en/events/2025-26/tokyo |
| Tokyo E-Prix 2 | formula-e | 🔴 Low | https://www.fiaformulae.com/en/events/2025-26/tokyo |

### ⚠️ Events to double-check

**Hidden Valley Raceway (GT World Challenge Australia) — Low**
Only the **Friday practice start (12:50 ACST)** and the day structure are confirmed from the SpeedSeries schedule announcement (Friday practice; Saturday qualifying + Race 1; Sunday Race 2). The exact clock times for **Free Practice 2, both qualifying sessions, Race 1 and Race 2 are estimated** (anchored to the confirmed Sat broadcast-from-10:00 / Sun broadcast-from-09:00 windows) — the official detailed timetable was not machine-readable. Structure modelled on the existing Phillip Island round (2× practice, 2× qualifying, 2× race). Timezone `Australia/Darwin` (ACST, no DST).

**Tokyo E-Prix 1 & 2 (Formula E) — Low**
Sources **conflict on the race dates**: MotorSportRadar/Hankook list the double-header as **24–25 July** (matching this repo's event dates: E‑Prix 2 = 24 Jul, E‑Prix 1 = 25 Jul), while other calendars list **25–26 July**. Per instructions I did **not** modify the stored event dates, so sessions are placed on each event's existing date. Exact session times could **not** be firmly verified from an official source — the night-race start (~20:05 JST) and an afternoon practice (~13:30 JST) appeared across sources, and qualifying (~15:40 JST) is an estimate. Treat all Tokyo times as provisional. Timezone `Asia/Tokyo`.

> Also worth a glance (not modified — outside the "add sessions" scope): the repo's stored **event dates** for Oschersleben (`2026-07-23 → 2026-07-25`) are a day narrower than the actual on-track days (24–26 Jul), and the DTM Race 2 session correctly falls on Sun 26 Jul.

### Sessions added

- **`backend/data/championships/dtm.json`** — Oschersleben: Free Practice 1/2, Qualifying 1, Race 1, Qualifying 2, Race 2 (6 sessions, `Europe/Berlin`).
- **`backend/data/championships/nascar-cup-series.json`** — Brickyard 400: Practice, Qualifying, Race (3 sessions, `America/New_York`, matching the file's NASCAR convention).
- **`backend/data/championships/gt-world-challenge-australia.json`** — Hidden Valley: Free Practice 1/2, Qualifying 1/2, Race 1, Race 2 (6 sessions, `Australia/Darwin`).
- **`backend/data/championships/formula-e.json`** — Tokyo E-Prix 1 and Tokyo E-Prix 2: Free Practice 1, Qualifying, Race each (3 sessions per E-Prix, `Asia/Tokyo`).

All four files pass the repo's existing `validate_data.py` Pydantic validators, and session formatting matches each file's existing conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164sC5RdWKSphjH5pmXnZzB

---
_Generated by [Claude Code](https://claude.ai/code/session_0164sC5RdWKSphjH5pmXnZzB)_