### PR TITLE
🏁 Sessions — week of 2026-07-27 (4 events)

### DIFF
--- a/backend/data/championships/gt-world-challenge-europe.json
+++ b/backend/data/championships/gt-world-challenge-europe.json
@@ -296,7 +296,44 @@
             "name": "Magny-Cours",
             "start_date": "2026-07-31",
             "end_date": "2026-08-02",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-07-31T13:30:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-07-31T20:40:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1",
+                    "start_time": "2026-08-01T14:55:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-08-01T21:05:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 2",
+                    "start_time": "2026-08-02T10:50:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 5
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-08-02T15:30:00",
+                    "timezone": "Europe/Paris",
+                    "session_number": 6
+                }
+            ]
         },
         {
             "slug": "nurburgring-gtwc-2026",

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -304,7 +304,32 @@
             "name": "Road America",
             "start_date": "2026-08-02",
             "end_date": "2026-08-02",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-07-31T11:25:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-01T09:50:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-01T15:25:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-02T10:40:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "virginia-international-raceway-2026",

--- a/backend/data/championships/supercars-championship.json
+++ b/backend/data/championships/supercars-championship.json
@@ -530,7 +530,80 @@
             "name": "Perth Super 440",
             "start_date": "2026-07-31",
             "end_date": "2026-08-02",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-07-31T15:00:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-07-31T15:40:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1 Race 1",
+                    "start_time": "2026-08-01T09:45:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying 2 Race 1",
+                    "start_time": "2026-08-01T10:05:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 1 Race 2",
+                    "start_time": "2026-08-01T10:35:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 5
+                },
+                {
+                    "name": "Qualifying 2 Race 2",
+                    "start_time": "2026-08-01T10:55:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 6
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-08-01T12:45:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 7
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-08-01T16:20:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 8
+                },
+                {
+                    "name": "Qualifying 1 Race 3",
+                    "start_time": "2026-08-02T11:00:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 9
+                },
+                {
+                    "name": "Qualifying 2 Race 3",
+                    "start_time": "2026-08-02T11:20:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 10
+                },
+                {
+                    "name": "Top Ten Shootout - Race 3",
+                    "start_time": "2026-08-02T11:45:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 11
+                },
+                {
+                    "name": "Race 3",
+                    "start_time": "2026-08-02T15:20:00",
+                    "timezone": "Australia/Perth",
+                    "session_number": 12
+                }
+            ]
         },
         {
             "slug": "ipswich-super-440-2026",

--- a/backend/data/championships/wrc.json
+++ b/backend/data/championships/wrc.json
@@ -1146,7 +1146,134 @@
             "name": "Finland Rally",
             "start_date": "2026-07-30",
             "end_date": "2026-08-02",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Shakedown",
+                    "start_time": "2026-07-30T09:01:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 1
+                },
+                {
+                    "name": "SS1 Harju 1",
+                    "start_time": "2026-07-30T19:05:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 2
+                },
+                {
+                    "name": "SS2 Laukaa 1",
+                    "start_time": "2026-07-31T08:44:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 3
+                },
+                {
+                    "name": "SS3 Saarikas 1",
+                    "start_time": "2026-07-31T09:45:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 4
+                },
+                {
+                    "name": "SS4 Sydänmaa 1",
+                    "start_time": "2026-07-31T10:50:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 5
+                },
+                {
+                    "name": "SS5 Hoho 1",
+                    "start_time": "2026-07-31T11:58:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 6
+                },
+                {
+                    "name": "SS6 Laukaa 2",
+                    "start_time": "2026-07-31T14:48:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 7
+                },
+                {
+                    "name": "SS7 Saarikas 2",
+                    "start_time": "2026-07-31T15:49:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 8
+                },
+                {
+                    "name": "SS8 Sydänmaa 2",
+                    "start_time": "2026-07-31T16:54:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 9
+                },
+                {
+                    "name": "SS9 Hoho 2",
+                    "start_time": "2026-07-31T18:05:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 10
+                },
+                {
+                    "name": "SS10 Harju 2",
+                    "start_time": "2026-07-31T19:05:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 11
+                },
+                {
+                    "name": "SS11 Parkkola 1",
+                    "start_time": "2026-08-01T08:01:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 12
+                },
+                {
+                    "name": "SS12 Päijälä 1",
+                    "start_time": "2026-08-01T09:42:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 13
+                },
+                {
+                    "name": "SS13 Västilä 1",
+                    "start_time": "2026-08-01T10:36:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 14
+                },
+                {
+                    "name": "SS14 Leustu 1",
+                    "start_time": "2026-08-01T12:05:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 15
+                },
+                {
+                    "name": "SS15 Parkkola 2",
+                    "start_time": "2026-08-01T15:01:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 16
+                },
+                {
+                    "name": "SS16 Päijälä 2",
+                    "start_time": "2026-08-01T16:42:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 17
+                },
+                {
+                    "name": "SS17 Västilä 2",
+                    "start_time": "2026-08-01T17:36:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 18
+                },
+                {
+                    "name": "SS18 Leustu 2",
+                    "start_time": "2026-08-01T19:05:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 19
+                },
+                {
+                    "name": "SS19 Himos-Jämsä 1",
+                    "start_time": "2026-08-02T10:35:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 20
+                },
+                {
+                    "name": "SS20 Himos-Jämsä 2 - Power Stage",
+                    "start_time": "2026-08-02T13:15:00",
+                    "timezone": "Europe/Helsinki",
+                    "session_number": 21
+                }
+            ]
         },
         {
             "slug": "paraguay-rally",


### PR DESCRIPTION
Automated session-timetable update. Source of truth: `GET /events/upcoming`. Of the 5 upcoming events returned, **NLS 7** already has sessions in the repo and was left untouched; the remaining **4** had empty `sessions` arrays and are populated here.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Finland Rally | wrc | ⚠️ Medium | [wikipedia.org/wiki/2026_Rally_Finland](https://en.wikipedia.org/wiki/2026_Rally_Finland) |
| Magny-Cours | gt-world-challenge-europe | ✅ High | [gt-world-challenge-europe.com timetable (PDF)](https://www.gt-world-challenge-europe.com/images/results/251/2026%20GT%20World%20-%20Magny-Cours%20-%20Timetable%20Draft%204.pdf) |
| Perth Super 440 | supercars-championship | ✅ High | [supercars.com](``https://www.supercars.com/news/supercars-news-2026-perth-track-schedule-revealed-super2-series-times-racing-repco-sprint-cup-supports``) |
| Road America | imsa | ⚠️ Medium | [motorsportscalendar.com](https://motorsportscalendar.com/event/imsa-2026-motul-sportscar-endurance-grand-prix) |

### ⚠️ Events to double-check
- **Finland Rally (Medium).** The 20-stage structure and total distance (316.04 km) are confirmed on the official [wrc.com event page](https://www.wrc.com/en/events/wrc-secto-rally-finland-2026), but the official per-stage timetable PDF wasn't machine-readable, so the individual stage **start times** come from Wikipedia's itinerary (times listed as "after HH:MM" first-car starts). Stage names/order are high confidence; exact minutes could still shift before the event.
- **Road America / IMSA (Medium).** The 6-hour race (Sun 10:40) and qualifying (Sat) are well corroborated, but the official IMSA schedule PDF and event page returned 403, so practice and qualifying **times** were taken from the motorsportscalendar aggregator. Only 2 practice sessions are listed there (matching the repo's other IMSA endurance rounds like Watkins Glen); a 3rd practice is possible. Qualifying time (15:25 CT) differs by ~5 min between sources (some list 15:20 CT).

### Sessions added
- **`wrc.json`** → `finland-rally`: 21 sessions — Shakedown + `SS1 Harju 1` … `SS20 Himos-Jämsä 2 - Power Stage` (timezone `Europe/Helsinki`).
- **`gt-world-challenge-europe.json`** → `magny-cours-2026`: 6 sessions — Free Practice 1/2, Qualifying 1, Race 1, Qualifying 2, Race 2 (`Europe/Paris`).
- **`supercars-championship.json`** → `perth-super-440-2026`: 12 sessions — Practice 1/2, per-race Qualifying 1/2, Races 1–3, Top Ten Shootout - Race 3 (`Australia/Perth`).
- **`imsa.json`** → `road-america-imsa-2026`: 4 sessions — Practice 1/2, Qualifying, Race (`America/Chicago`).

Support series and sponsor prefixes were excluded; main-event sessions only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dAYdbb21oESqPLQ1ufysA)_