### PR TITLE
🏁 Sessions — week of 2026-08-03 (3 events)

### DIFF
--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -484,7 +484,38 @@
             "name": "Grand Prix of Portland",
             "start_date": "2026-08-07",
             "end_date": "2026-08-09",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-07T14:30:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-08T10:00:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-08T16:00:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 3
+                },
+                {
+                    "name": "Warm-Up",
+                    "start_time": "2026-08-09T10:00:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-09T13:00:00",
+                    "timezone": "America/Los_Angeles",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "indy-at-markham-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -543,7 +543,26 @@
             "name": "Iowa 350",
             "start_date": "2026-08-09",
             "end_date": "2026-08-09",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-08-08T13:05:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-08T14:10:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-09T14:30:00",
+                    "timezone": "America/Chicago",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "richmond-400-2026",

--- a/backend/data/championships/super-formula.json
+++ b/backend/data/championships/super-formula.json
@@ -164,7 +164,32 @@
             "name": "Sportsland SUGO",
             "start_date": "2026-08-07",
             "end_date": "2026-08-09",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-08-08T09:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-08T13:45:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 2
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-08-09T09:00:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-09T13:45:00",
+                    "timezone": "Asia/Tokyo",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "fuji-2-2026",


### PR DESCRIPTION
Automated session timetables for upcoming events returned by `GET /events/upcoming` that had no sessions.

The API returned 4 upcoming events. **British Grand Prix** (MotoGP) already has 8 sessions in the repo/DB, so it was excluded. The remaining 3 had empty session arrays and are added here.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Grand Prix of Portland | indycar-series | ✅ High | https://www.indycar.com/Schedule/2026/Portland |
| Iowa 350 | nascar-cup-series | ✅ High | https://www.nascar.com/weekend-schedule/weekend-schedule-for-2026-iowa-speedway/ |
| Sportsland SUGO | super-formula | ⚠️ Medium | https://superformula.net/sf3/ |

### ⚠️ Events to double-check
- **Sportsland SUGO (Super Formula, Round 8)** — ⚠️ Medium. The official Sportsland SUGO / Super Formula timetable is published only as an image, so exact per-session green-flag times could not be scraped directly. Times are derived from the published Japanese program schedule (Sat Aug 8: free practice 09:00–12:00, qualifying 13:45–17:00; Sun Aug 9: free practice 09:00–12:00, race 13:45–18:00). Session **start times use the on-track window starts** and the exact Super Formula green-flag times may shift by up to ~1 hour. The single-race weekend format (FP1 / Qualifying / FP2 / Race) matches the repo's existing single-race SF rounds (e.g. Autopolis). Note: the repo's event `start_date` is 2026-08-07, but the round runs 2026-08-08/09 — sessions are dated to the actual race days and the event dates were left unchanged.

### Sessions added
- **`backend/data/championships/super-formula.json`** — `sugo-2026`: Free Practice 1 (Aug 8, 09:00), Qualifying (Aug 8, 13:45), Free Practice 2 (Aug 9, 09:00), Race (Aug 9, 13:45) — `Asia/Tokyo`.
- **`backend/data/championships/indycar-series.json`** — `grand-prix-of-portland-2026`: Practice 1 (Aug 7, 14:30), Practice 2 (Aug 8, 10:00), Qualifying (Aug 8, 16:00), Warm-Up (Aug 9, 10:00), Race (Aug 9, 13:00) — `America/Los_Angeles`. (Official IndyCar ET times converted to local Pacific.)
- **`backend/data/championships/nascar-cup-series.json`** — `iowa-350-2026`: Practice (Aug 8, 13:05), Qualifying (Aug 8, 14:10), Race (Aug 9, 14:30) — `America/Chicago`. (Official ET times — practice 2:05pm, qualifying 3:10pm, race 3:30pm ET — converted to local Central.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ86XPxrwTtTot7cvUaCH7)_