### PR TITLE
🏁 Sessions — week of 2026-08-10 (5 events)

### DIFF
--- a/backend/data/championships/dtm.json
+++ b/backend/data/championships/dtm.json
@@ -195,7 +195,44 @@
             "name": "Nürburgring",
             "start_date": "2026-08-14",
             "end_date": "2026-08-16",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "session_number": 1,
+                    "start_time": "2026-08-14T11:30:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Free Practice 2",
+                    "session_number": 2,
+                    "start_time": "2026-08-14T16:00:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Qualifying 1",
+                    "session_number": 3,
+                    "start_time": "2026-08-15T09:55:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Race 1",
+                    "session_number": 4,
+                    "start_time": "2026-08-15T13:30:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Qualifying 2",
+                    "session_number": 5,
+                    "start_time": "2026-08-16T09:10:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "name": "Race 2",
+                    "session_number": 6,
+                    "start_time": "2026-08-16T13:30:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
         },
         {
             "slug": "sachsenring-2026",

--- a/backend/data/championships/formula-e.json
+++ b/backend/data/championships/formula-e.json
@@ -160,14 +160,23 @@
             "name": "London E-Prix 1",
             "start_date": "2026-08-15",
             "end_date": "2026-08-15",
-            "sessions": []
+            "sessions": [
+            { "name": "Free Practice 1", "start_time": "2026-08-14T16:00:00", "timezone": "Europe/London", "session_number": 1 },
+            { "name": "Free Practice 2", "start_time": "2026-08-15T08:30:00", "timezone": "Europe/London", "session_number": 2 },
+            { "name": "Qualifying", "start_time": "2026-08-15T10:40:00", "timezone": "Europe/London", "session_number": 3 },
+            { "name": "Race", "start_time": "2026-08-15T15:05:00", "timezone": "Europe/London", "session_number": 4 }
+            ]
         },
         {
             "slug": "london-eprix-2-2026",
             "name": "London E-Prix 2",
             "start_date": "2026-08-16",
             "end_date": "2026-08-16",
-            "sessions": []
+            "sessions": [
+            { "name": "Free Practice 3", "start_time": "2026-08-16T08:30:00", "timezone": "Europe/London", "session_number": 1 },
+            { "name": "Qualifying", "start_time": "2026-08-16T10:40:00", "timezone": "Europe/London", "session_number": 2 },
+            { "name": "Race", "start_time": "2026-08-16T15:05:00", "timezone": "Europe/London", "session_number": 3 }
+            ]
         }
     ]
 }

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -491,7 +491,38 @@
             "name": "Indy at Markham",
             "start_date": "2026-08-14",
             "end_date": "2026-08-16",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-14T15:00:00",
+                    "timezone": "America/Toronto",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-15T10:00:00",
+                    "timezone": "America/Toronto",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-15T14:25:00",
+                    "timezone": "America/Toronto",
+                    "session_number": 3
+                },
+                {
+                    "name": "Warm-Up",
+                    "start_time": "2026-08-16T08:30:00",
+                    "timezone": "America/Toronto",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-16T12:00:00",
+                    "timezone": "America/Toronto",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "washington-dc-grand-prix-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -550,7 +550,26 @@
             "name": "Richmond 400",
             "start_date": "2026-08-15",
             "end_date": "2026-08-15",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-14T15:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-14T16:40:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-15T19:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "new-hampshire-300-2026",


### PR DESCRIPTION
Populated the empty `sessions` arrays for the 5 upcoming events returned by `GET /events/upcoming` (week of 14–16 Aug 2026). Session timetables were researched from official championship sources and cross-referenced where possible. All files pass `scripts/validate_data.py`.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Richmond 400 | nascar-cup-series | ✅ High | https://www.richmond400.com/en/schedule-6 |
| London E-Prix 1 | formula-e | ✅ High | https://formulaelondon.com/ |
| London E-Prix 2 | formula-e | ✅ High | https://formulaelondon.com/ |
| Nürburgring | dtm | ⚠️ Medium | https://motorsportscalendar.com/event/dtm-2026-n-rburgring |
| Indy at Markham | indycar-series | ⚠️ Medium | https://motorsportscalendar.com/event/indycar-2026-ontario-honda-dealers-indy-at-markham |

### ⚠️ Events to double-check
- **Nürburgring (dtm) — Medium.** The official Nürburgring/DTM timetable is not yet published (both `nuerburgring.de` and `racecountdown.com` still show "session times not yet announced"). Times were taken from a single aggregator (motorsportscalendar) and follow the standard DTM weekend format (2× Free Practice Fri, Qualifying + Race Sat, Qualifying + Race Sun). Verify exact start times once the official schedule is released.
- **Indy at Markham (indycar-series) — Medium.** This is a brand-new street circuit (first IndyCar race at Markham). The **Race** start time (12:00 noon Sun) is confirmed by the official INDYCAR site, but the Practice/Qualifying/Warm-Up times come from a single aggregator (motorsportscalendar) and may still be provisional. Re-check nearer the event.

### Sessions added
- **`backend/data/championships/nascar-cup-series.json`** → `richmond-400-2026`: Practice 1 (Fri 15:30), Qualifying (Fri 16:40), Race (Sat 19:00) — `America/New_York`.
- **`backend/data/championships/formula-e.json`** → `london-eprix-1-2026`: Free Practice 1 (Fri 16:00), Free Practice 2 (Sat 08:30), Qualifying (Sat 10:40), Race (Sat 15:05) — `Europe/London`.
- **`backend/data/championships/formula-e.json`** → `london-eprix-2-2026`: Free Practice 3 (Sun 08:30), Qualifying (Sun 10:40), Race (Sun 15:05) — `Europe/London`. (Follows the existing repo convention for FE double-headers, e.g. Monaco/Shanghai: E-Prix 1 carries FP1+FP2, E-Prix 2 carries FP3.)
- **`backend/data/championships/dtm.json`** → `nurburgring-dtm-2026`: Free Practice 1 (Fri 11:30), Free Practice 2 (Fri 16:00), Qualifying 1 (Sat 09:55), Race 1 (Sat 13:30), Qualifying 2 (Sun 09:10), Race 2 (Sun 13:30) — `Europe/Berlin`.
- **`backend/data/championships/indycar-series.json`** → `indy-at-markham-2026`: Practice 1 (Fri 15:00), Practice 2 (Sat 10:00), Qualifying (Sat 14:25), Warm-Up (Sun 08:30), Race (Sun 12:00) — `America/Toronto`.

Only the `sessions` arrays of these five events were modified; no other fields or events were touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts8joqtXYkF25hcqfnkA4q)_