### PR TITLE
🏁 Sessions — week of 2026-08-17 (6 events)

### DIFF
--- a/backend/data/championships/elms.json
+++ b/backend/data/championships/elms.json
@@ -54,7 +54,56 @@
             "name": "4 Hours of Spa-Francorchamps",
             "start_date": "2026-08-21",
             "end_date": "2026-08-23",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-08-21T11:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 1
+                },
+                {
+                    "name": "Bronze Test",
+                    "start_time": "2026-08-21T14:10:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 2
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-08-22T09:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying LMGT3",
+                    "start_time": "2026-08-22T12:30:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying LMP3",
+                    "start_time": "2026-08-22T12:52:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 5
+                },
+                {
+                    "name": "Qualifying LMP2 Pro/Am",
+                    "start_time": "2026-08-22T13:14:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 6
+                },
+                {
+                    "name": "Qualifying LMP2",
+                    "start_time": "2026-08-22T13:36:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 7
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-23T13:00:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 8
+                }
+            ]
         },
         {
             "slug": "4-hours-of-silverstone-2026",

--- a/backend/data/championships/imsa.json
+++ b/backend/data/championships/imsa.json
@@ -311,7 +311,32 @@
             "name": "Virginia International Raceway",
             "start_date": "2026-08-23",
             "end_date": "2026-08-23",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-21T15:10:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-22T10:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-22T16:50:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-23T12:10:00",
+                    "timezone": "America/New_York",
+                    "session_number": 4
+                }
+            ]
         },
         {
             "slug": "indianapolis-motor-speedway-2026",

--- a/backend/data/championships/indycar-series.json
+++ b/backend/data/championships/indycar-series.json
@@ -498,7 +498,38 @@
             "name": "Washington D.C. Grand Prix",
             "start_date": "2026-08-21",
             "end_date": "2026-08-23",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-22T09:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-22T13:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-22T17:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                },
+                {
+                    "name": "Warm-Up",
+                    "start_time": "2026-08-23T09:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 4
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-23T13:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 5
+                }
+            ]
         },
         {
             "slug": "milwaukee-mile-2026",

--- a/backend/data/championships/le-mans-cup.json
+++ b/backend/data/championships/le-mans-cup.json
@@ -70,7 +70,44 @@
             "name": "Spa-Francorchamps Round",
             "start_date": "2026-08-21",
             "end_date": "2026-08-22",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Free Practice 1",
+                    "start_time": "2026-08-21T09:50:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 1
+                },
+                {
+                    "name": "Free Practice 2",
+                    "start_time": "2026-08-21T14:50:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1",
+                    "start_time": "2026-08-22T11:25:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying 2",
+                    "start_time": "2026-08-22T11:45:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 3",
+                    "start_time": "2026-08-22T12:05:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 5
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-22T15:52:00",
+                    "timezone": "Europe/Brussels",
+                    "session_number": 6
+                }
+            ]
         },
         {
             "slug": "silverstone-2026",

--- a/backend/data/championships/nascar-cup-series.json
+++ b/backend/data/championships/nascar-cup-series.json
@@ -557,7 +557,26 @@
             "name": "New Hampshire 300",
             "start_date": "2026-08-23",
             "end_date": "2026-08-23",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice",
+                    "start_time": "2026-08-22T10:30:00",
+                    "timezone": "America/New_York",
+                    "session_number": 1
+                },
+                {
+                    "name": "Qualifying",
+                    "start_time": "2026-08-22T11:35:00",
+                    "timezone": "America/New_York",
+                    "session_number": 2
+                },
+                {
+                    "name": "Race",
+                    "start_time": "2026-08-23T15:00:00",
+                    "timezone": "America/New_York",
+                    "session_number": 3
+                }
+            ]
         },
         {
             "slug": "daytona-400-2026",

--- a/backend/data/championships/supercars-championship.json
+++ b/backend/data/championships/supercars-championship.json
@@ -537,7 +537,80 @@
             "name": "Ipswich Super 440",
             "start_date": "2026-08-21",
             "end_date": "2026-08-23",
-            "sessions": []
+            "sessions": [
+                {
+                    "name": "Practice 1",
+                    "start_time": "2026-08-21T14:40:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 1
+                },
+                {
+                    "name": "Practice 2",
+                    "start_time": "2026-08-21T15:30:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 2
+                },
+                {
+                    "name": "Qualifying 1 - Race 1",
+                    "start_time": "2026-08-22T10:00:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 3
+                },
+                {
+                    "name": "Qualifying 2 - Race 1",
+                    "start_time": "2026-08-22T10:20:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 4
+                },
+                {
+                    "name": "Qualifying 1 - Race 2",
+                    "start_time": "2026-08-22T10:50:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 5
+                },
+                {
+                    "name": "Qualifying 2 - Race 2",
+                    "start_time": "2026-08-22T11:10:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 6
+                },
+                {
+                    "name": "Race 1",
+                    "start_time": "2026-08-22T12:45:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 7
+                },
+                {
+                    "name": "Race 2",
+                    "start_time": "2026-08-22T16:15:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 8
+                },
+                {
+                    "name": "Qualifying 1 - Race 3",
+                    "start_time": "2026-08-23T10:55:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 9
+                },
+                {
+                    "name": "Qualifying 2 - Race 3",
+                    "start_time": "2026-08-23T11:15:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 10
+                },
+                {
+                    "name": "Top Ten Shootout - Race 3",
+                    "start_time": "2026-08-23T11:40:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 11
+                },
+                {
+                    "name": "Race 3",
+                    "start_time": "2026-08-23T15:20:00",
+                    "timezone": "Australia/Brisbane",
+                    "session_number": 12
+                }
+            ]
         },
         {
             "slug": "500-at-the-bend-2026",


### PR DESCRIPTION
Automated session-timetable pass over the events returned by `GET /events/upcoming`. Seven events were returned; the Dutch Grand Prix already had sessions, leaving **6 events** with empty `sessions` arrays. Each was researched from official sources and populated following the existing per-championship conventions in the repo.

### Summary
| Event | Championship | Confidence | Source |
|-------|-------------|------------|--------|
| Washington D.C. Grand Prix | `indycar-series` | ✅ High | [indycar.com](https://www.indycar.com/news/2026/07/07-16-dc-schedule) |
| 4 Hours of Spa-Francorchamps | `elms` | ✅ High | [europeanlemansseries.com](https://www.europeanlemansseries.com/en/race/4-hours-of-spa-francorchamps-2026) |
| New Hampshire 300 | `nascar-cup-series` | ✅ High | [nhms.com](https://www.nhms.com/events/nascar-cup-series/schedule/) |
| Virginia International Raceway | `imsa` | ✅ High | [imsa.com / motorsportscalendar.com](https://motorsportscalendar.com/event/imsa-2026-michelin-gt-challenge-at-vir) |
| Spa-Francorchamps Round | `le-mans-cup` | ⚠️ Medium | [lemanscup.com](https://www.lemanscup.com/en/race/spa-francorchamps-round-2026) |
| Ipswich Super 440 | `supercars-championship` | ⚠️ Medium | [supercars.com](``https://www.supercars.com/news/supercars-news-2026-ipswich-super-440-track-schedule-revealed-sprint-cup-finale-race-start-times``) |

### ⚠️ Events to double-check

- **Spa-Francorchamps Round (`le-mans-cup`) — Medium.** Times come from the official Le Mans Cup page, but the three qualifying sessions were labelled by class there (GT3, LMP3 Pro/Am, LMP3). To match this repo's existing `le-mans-cup` convention (Barcelona round uses generic `Qualifying 1/2/3`), they were mapped chronologically to `Qualifying 1` (GT3, 11:25), `Qualifying 2` (LMP3 Pro/Am, 11:45) and `Qualifying 3` (LMP3, 12:05). The official page also lists a "Bronze Driver Collective Test" on Friday, which was **omitted** because the existing `le-mans-cup` events don't include the test as a session. Race is Saturday 15:52.
- **Ipswich Super 440 (`supercars-championship`) — Medium.** Times are from the official Supercars track-schedule article. The 2026 sprint format runs two knockout qualifying segments (Q1/Q2) per race; the source uses championship race numbers (Race 26/27/28) which were mapped to round-local `Race 1/2/3`. Qualifying segments were named `Qualifying 1 - Race N` / `Qualifying 2 - Race N` (blending the source's Q1/Q2 with this repo's `Qualifying - Race N` suffix). The Sunday finale keeps the `Top Ten Shootout - Race 3` naming already used in the file.

### Sessions added

- **`backend/data/championships/indycar-series.json`** — `washington-dc-grand-prix-2026`: 5 sessions (Practice 1, Practice 2, Qualifying, Warm-Up, Race), `America/New_York`. No Friday running per official schedule.
- **`backend/data/championships/elms.json`** — `4-hours-of-spa-2026`: 8 sessions (Free Practice 1, Bronze Test, Free Practice 2, Qualifying LMGT3/LMP3/LMP2 Pro-Am/LMP2, Race), `Europe/Brussels`.
- **`backend/data/championships/nascar-cup-series.json`** — `new-hampshire-300-2026`: 3 sessions (Practice, Qualifying, Race), `America/New_York`.
- **`backend/data/championships/imsa.json`** — `virginia-international-raceway-2026`: 4 sessions (Practice 1, Practice 2, Qualifying, Race), `America/New_York`.
- **`backend/data/championships/le-mans-cup.json`** — `spa-2026`: 6 sessions (Free Practice 1/2, Qualifying 1/2/3, Race), `Europe/Brussels`.
- **`backend/data/championships/supercars-championship.json`** — `ipswich-super-440-2026`: 12 sessions (Practice 1/2, two qualifying segments + races for Races 1–2, qualifying segments + Top Ten Shootout + Race 3), `Australia/Brisbane`.

Only the empty `sessions` arrays for these 6 events were changed; no other content was touched.

> **Note on branch:** this session's environment mandates development on `claude/eloquent-tesla-jc426h`, so the PR is opened from that branch rather than a `sessions/2026-08-17` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeRHAm8FLpjsQUFcpFGtoQ)_